### PR TITLE
When calling `ago` specify that we are talking in seconds.

### DIFF
--- a/lib/devise_security_extension/models/expirable.rb
+++ b/lib/devise_security_extension/models/expirable.rb
@@ -79,7 +79,7 @@ module Devise
 
         # Scope method to collect all expired users since +time+ ago
         def expired_for(time = delete_expired_after)
-          where('expired_at < ?', time.ago)
+          where('expired_at < ?', time.seconds.ago)
         end
 
         # Sample method for daily cron to delete all expired entries after a 

--- a/lib/devise_security_extension/models/password_expirable.rb
+++ b/lib/devise_security_extension/models/password_expirable.rb
@@ -14,7 +14,7 @@ module Devise
       # is an password change required?
       def need_change_password?
         if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
-          self.password_changed_at.nil? or self.password_changed_at < self.expire_password_after.ago
+          self.password_changed_at.nil? or self.password_changed_at < self.expire_password_after.seconds.ago
         else
           false
         end
@@ -31,7 +31,7 @@ module Devise
       # set a fake datetime so a password change is needed
       def need_change_password
         if self.expire_password_after.is_a? Fixnum or self.expire_password_after.is_a? Float
-          self.password_changed_at = self.expire_password_after.ago
+          self.password_changed_at = self.expire_password_after.seconds.ago
         end
 
         # is date not set it will set default to need set new password next login


### PR DESCRIPTION
This removes a deprecation warning in Rails 4.1

cherry-picked as per https://github.com/phatworx/devise_security_extension/pull/147
